### PR TITLE
Consent Validation

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - CloudMine (1.7.8):
     - AFNetworking (~> 2.5.4)
     - MAObjCRuntime (~> 0.0.1)
-  - CMHealth (0.1.0):
+  - CMHealth (0.1.2):
     - CloudMine (~> 1.7)
     - ResearchKit (~> 1.3)
   - Expecta (1.0.5)
@@ -43,7 +43,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
   CloudMine: 90ca98d8a4ff2b782ad8633706dd33adc2be560c
-  CMHealth: c1ac9df1862988a84122cbfef1e637a8b553947b
+  CMHealth: b8a22b81abd77c464826eb1be6eb82896cc416d7
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   MAObjCRuntime: a6a1d95acbfa3784d66cb35bd42904e47943b488
   ResearchKit: 934a1efefed1a3a9150002a1e4b123d0c86c3f2e

--- a/Pod/Classes/CMHConsentValidator.h
+++ b/Pod/Classes/CMHConsentValidator.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import <ResearchKit/ResearchKit.h>
+
+@interface CMHConsentValidator : NSObject
+
++ (ORKConsentSignature *_Nullable)signatureFromConsentResults:(ORKTaskResult *_Nullable)consentResult error:(NSError * __autoreleasing *)errorPtr;
+
+@end

--- a/Pod/Classes/CMHConsentValidator.m
+++ b/Pod/Classes/CMHConsentValidator.m
@@ -1,0 +1,79 @@
+#import "CMHConsentValidator.h"
+#import "CMHErrorUtilities.h"
+
+@implementation CMHConsentValidator
+
++ (ORKConsentSignature *_Nullable)signatureFromConsentResults:(ORKTaskResult *_Nullable)consentResult error:(NSError * __autoreleasing *)errorPtr
+{
+    if (nil == consentResult) {
+        *errorPtr = [CMHErrorUtilities errorWithCode:CMHErrorUserMissingConsent
+                           localizedDescription:NSLocalizedString(@"Must complete a consent step", nil)];
+        return nil;
+    }
+
+    ORKConsentSignatureResult *signatureResult = [self signatureInResults:consentResult.results];
+    ORKConsentSignature *signature = signatureResult.signature;
+
+    if (nil == signatureResult || nil == signature) {
+        *errorPtr = [CMHErrorUtilities errorWithCode:CMHErrorUserMissingSignature
+                           localizedDescription:NSLocalizedString(@"Consent must contain a valid signature", nil)];
+        return nil;
+    }
+
+    if (!signatureResult.consented) {
+        *errorPtr = [CMHErrorUtilities errorWithCode:CMHErrorUserDidNotConsent
+                                localizedDescription:NSLocalizedString(@"Must agree to study consent", nil)];
+        return nil;
+    }
+
+    if ([self signatureIsMissingName:signature]) {
+        *errorPtr = [CMHErrorUtilities errorWithCode:CMHErrorUserDidNotProvideName
+                                localizedDescription:NSLocalizedString(@"Must provide family and given names", nil)];
+        return nil;
+    }
+
+    if (nil == signature.signatureImage) {
+        *errorPtr = [CMHErrorUtilities errorWithCode:CMHErrorUserDidNotSign
+                                localizedDescription:NSLocalizedString(@"Must provide signature image", nil)];
+        return nil;
+    }
+
+    return signature;
+}
+
+# pragma mark Private
++ (ORKConsentSignatureResult *_Nullable)signatureInResults:(NSArray<ORKResult *> *_Nullable)results
+{
+    if (nil == results) {
+        return nil;
+    }
+
+    // Check these results
+    for (ORKResult *aResult in results) {
+        if ([aResult isKindOfClass:[ORKConsentSignatureResult class]]) {
+            return (ORKConsentSignatureResult *)aResult;
+        }
+    }
+
+    // Recusrively check results of results
+    for (ORKResult *aResult in results) {
+        if (![aResult respondsToSelector:@selector(results)]) {
+            continue;
+        }
+
+        ORKConsentSignatureResult *recusrivResult = [self signatureInResults:[aResult performSelector:@selector(results)]];
+        if (nil != recusrivResult) {
+            return recusrivResult;
+        }
+    }
+
+    return nil;
+}
+
++ (BOOL)signatureIsMissingName:(ORKConsentSignature *_Nonnull)signature
+{
+    return nil == (signature.givenName || [signature.givenName isEqualToString:@""] ||
+                   nil == signature.familyName || [signature.familyName isEqualToString:@""]);
+}
+
+@end

--- a/Pod/Classes/CMHErrorUtilities.h
+++ b/Pod/Classes/CMHErrorUtilities.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import "CMHErrors.h"
+
+@interface CMHErrorUtilities : NSObject
+
++ (NSError *_Nonnull)errorWithCode:(CMHError)code localizedDescription:(NSString *_Nonnull)description;
+
+@end

--- a/Pod/Classes/CMHErrorUtilities.m
+++ b/Pod/Classes/CMHErrorUtilities.m
@@ -1,0 +1,12 @@
+#import "CMHErrorUtilities.h"
+
+@implementation CMHErrorUtilities
+
++ (NSError *_Nonnull)errorWithCode:(CMHError)code localizedDescription:(NSString *_Nonnull)description
+{
+    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: description };
+    NSError *error = [NSError errorWithDomain:CMHErrorDomain code:code userInfo:userInfo];
+    return error;
+}
+
+@end

--- a/Pod/Classes/CMHErrors.h
+++ b/Pod/Classes/CMHErrors.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+#ifndef CMHErrors_h
+#define CMHErrors_h
+
+static NSString *const CMHErrorDomain = @"CMHErrorDomain";
+
+typedef NS_ENUM(NSUInteger, CMHError) {
+    CMHErrorUserMissingConsent      = 700,
+    CMHErrorUserMissingSignature    = 701,
+    CMHErrorUserDidNotConsent       = 702,
+    CMHErrorUserDidNotProvideName   = 703,
+    CMHErrorUserDidNotSign          = 704
+};
+
+#endif

--- a/Pod/Classes/CMHErrors.h
+++ b/Pod/Classes/CMHErrors.h
@@ -3,7 +3,7 @@
 #ifndef CMHErrors_h
 #define CMHErrors_h
 
-static NSString *const CMHErrorDomain = @"CMHErrorDomain";
+static NSString *const CMHErrorDomain = @"me.cloudmine.CMHealth.ErrorDomain";
 
 typedef NS_ENUM(NSUInteger, CMHError) {
     CMHErrorUserMissingConsent      = 700,

--- a/Pod/Classes/CMHealth.h
+++ b/Pod/Classes/CMHealth.h
@@ -2,6 +2,7 @@
 #import <ResearchKit/ResearchKit.h>
 #import <CloudMine/CloudMine.h>
 
+#import "CMHErrors.h"
 #import "CMHUserData.h"
 #import "CMHUser.h"
 #import "ORKResult+CMHealth.h"


### PR DESCRIPTION
Before signing a user up, validation the consent task supplied by the SDK-consumer. Also lays the ground work for uniform error generation across the SDK.