### PR TITLE
Upload Consent Signature Image

### DIFF
--- a/CMHealth.podspec
+++ b/CMHealth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "CMHealth"
-  s.version          = "0.1.3"
+  s.version          = "0.1.4"
   s.summary          = "Store and retrieve ResearchKit data to CloudMine with ease"
   s.description      = <<-DESC
                         Store and retrieve ResearchKit data to CloudMine's backend with ease.

--- a/Pod/Classes/CMHConsent.h
+++ b/Pod/Classes/CMHConsent.h
@@ -1,0 +1,8 @@
+#import <CloudMine/CloudMine.h>
+#import <ResearchKit/ResearchKit.h>
+
+@interface CMHConsent : CMObject
+
+@property (nonatomic, nullable, readonly) ORKTaskResult *consentResult;
+
+@end

--- a/Pod/Classes/CMHConsent.m
+++ b/Pod/Classes/CMHConsent.m
@@ -1,0 +1,32 @@
+#import "CMHConsent_internal.h"
+#import "Cocoa+CMHealth.h"
+
+@implementation CMHConsent
+
+- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *)consentResult
+{
+    self = [super init];
+    if (nil == self) return nil;
+
+    self.consentResult = consentResult;
+
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (nil == self) return nil;
+
+    self.consentResult = [aDecoder decodeObjectForKey:@"consentResult"];
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [super encodeWithCoder:aCoder];
+    [aCoder encodeObject:self.consentResult forKey:@"consentResult"];
+}
+
+@end

--- a/Pod/Classes/CMHConsent.m
+++ b/Pod/Classes/CMHConsent.m
@@ -3,12 +3,13 @@
 
 @implementation CMHConsent
 
-- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *)consentResult
+- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *)consentResult andSignatureImageFilename:(NSString *)filename
 {
     self = [super init];
     if (nil == self) return nil;
 
     self.consentResult = consentResult;
+    self.signatureImageFilename = filename;
 
     return self;
 }
@@ -19,6 +20,7 @@
     if (nil == self) return nil;
 
     self.consentResult = [aDecoder decodeObjectForKey:@"consentResult"];
+    self.signatureImageFilename = [aDecoder decodeObjectForKey:@"signatureImageFilename"];
 
     return self;
 }
@@ -27,6 +29,7 @@
 {
     [super encodeWithCoder:aCoder];
     [aCoder encodeObject:self.consentResult forKey:@"consentResult"];
+    [aCoder encodeObject:self.signatureImageFilename forKey:@"signatureImageFilename"];
 }
 
 @end

--- a/Pod/Classes/CMHConsentValidator.h
+++ b/Pod/Classes/CMHConsentValidator.h
@@ -3,6 +3,6 @@
 
 @interface CMHConsentValidator : NSObject
 
-+ (ORKConsentSignature *_Nullable)signatureFromConsentResults:(ORKTaskResult *_Nullable)consentResult error:(NSError * __autoreleasing *)errorPtr;
++ (ORKConsentSignature *_Nullable)signatureFromConsentResults:(ORKTaskResult *_Nullable)consentResult error:(NSError * __autoreleasing _Nullable * _Nullable)errorPtr;
 
 @end

--- a/Pod/Classes/CMHConsentValidator.m
+++ b/Pod/Classes/CMHConsentValidator.m
@@ -72,7 +72,7 @@
 
 + (BOOL)signatureIsMissingName:(ORKConsentSignature *_Nonnull)signature
 {
-    return nil == (signature.givenName || [signature.givenName isEqualToString:@""] ||
+    return (nil == signature.givenName || [signature.givenName isEqualToString:@""] ||
                    nil == signature.familyName || [signature.familyName isEqualToString:@""]);
 }
 

--- a/Pod/Classes/CMHConsent_internal.h
+++ b/Pod/Classes/CMHConsent_internal.h
@@ -4,8 +4,9 @@
 #import "CMHConsent.h"
 
 @interface CMHConsent ()
-- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *_Nullable)consentResult;
+- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *_Nullable)consentResult andSignatureImageFilename:(NSString *_Nullable)filename;
 @property (nonatomic, nullable, readwrite) ORKTaskResult *consentResult;
+@property (nonatomic, nullable, readwrite) NSString *signatureImageFilename;
 @end
 
 #endif

--- a/Pod/Classes/CMHConsent_internal.h
+++ b/Pod/Classes/CMHConsent_internal.h
@@ -1,0 +1,11 @@
+#ifndef CMHConsent_internal_h
+#define CMHConsent_internal_h
+
+#import "CMHConsent.h"
+
+@interface CMHConsent ()
+- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *_Nullable)consentResult;
+@property (nonatomic, nullable, readwrite) ORKTaskResult *consentResult;
+@end
+
+#endif

--- a/Pod/Classes/CMHErrors.h
+++ b/Pod/Classes/CMHErrors.h
@@ -10,7 +10,8 @@ typedef NS_ENUM(NSUInteger, CMHError) {
     CMHErrorUserMissingSignature    = 701,
     CMHErrorUserDidNotConsent       = 702,
     CMHErrorUserDidNotProvideName   = 703,
-    CMHErrorUserDidNotSign          = 704
+    CMHErrorUserDidNotSign          = 704,
+    CMHErrorFailedToUploadSignature = 705
 };
 
 #endif

--- a/Pod/Classes/CMHUser.m
+++ b/Pod/Classes/CMHUser.m
@@ -68,10 +68,11 @@
         }
 
         self.userData = [[CMHUserData alloc] initWithInternalUser:[CMHInternalUser currentUser]];
+        [CMStore defaultStore].user = [CMHInternalUser currentUser];
+        
         NSData *signatureData = UIImageJPEGRepresentation(signature.signatureImage, 1.0);
 
-        // TODO: Generate the image name based on study id
-        [[CMStore defaultStore] saveUserFileWithData:signatureData named:@"consent.jpg" additionalOptions:nil callback:^(CMFileUploadResponse *fileResponse) {
+        [[CMStore defaultStore] saveUserFileWithData:signatureData additionalOptions:nil callback:^(CMFileUploadResponse *fileResponse) {
             NSError *fileUploadError = [CMHUser errorForSignatureUploadResponse:fileResponse];
             if (nil != fileUploadError) {
                 if (nil != block) {


### PR DESCRIPTION
User consent is now wrapped in an explicit `CMObject` subclass. This subclass has two properties (currently), the `ORKTaskResult` object from the user's consent, and a string representing the user filename of the signature image on CloudMine.

The `CMConsent` object is created and uploaded after the signature has been extracted and uploaded from the consent results. It is a read only representation of consent from the SDK consumer's standpoint, and it's creation is internal to the SDK. A future update will add the ability to fetch the consent object and the consent signature from CloudMine.