### PR TITLE
Support Study Descriptor on ORK Objects

### DIFF
--- a/CMHealth.podspec
+++ b/CMHealth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "CMHealth"
-  s.version          = "0.1.4"
+  s.version          = "0.1.5"
   s.summary          = "Store and retrieve ResearchKit data to CloudMine with ease"
   s.description      = <<-DESC
                         Store and retrieve ResearchKit data to CloudMine's backend with ease.

--- a/Pod/Classes/CMHConstants_internal.h
+++ b/Pod/Classes/CMHConstants_internal.h
@@ -1,0 +1,6 @@
+#ifndef CMHConstants_internal_h
+#define CMHConstants_internal_h
+
+static NSString *const CMHStudyDescriptorKey = @"studyDescriptor";
+
+#endif

--- a/Pod/Classes/CMHResultWrapper.h
+++ b/Pod/Classes/CMHResultWrapper.h
@@ -3,7 +3,7 @@
 
 @interface CMHResultWrapper : CMObject
 
-- (_Nonnull instancetype)initWithResult:(ORKResult *_Nonnull)result;
+- (_Nonnull instancetype)initWithResult:(ORKResult *_Nonnull)result studyDescriptor:(NSString *_Nullable)descriptor;
 - (_Nonnull instancetype)initWithCoder:(NSCoder *_Nonnull)aDecoder;
 - (ORKResult *_Nullable)wrappedResult;
 + (_Nonnull Class)wrapperClassForResultClass:(_Nonnull Class)resultClass;

--- a/Pod/Classes/CMHResultWrapper.m
+++ b/Pod/Classes/CMHResultWrapper.m
@@ -1,5 +1,6 @@
 #import "CMHResultWrapper.h"
 #import <objc/runtime.h>
+#import "CMHConstants_internal.h"
 
 @interface CMHResultWrapper ()
 @property (nonatomic, nonnull) ORKResult *result;
@@ -40,7 +41,7 @@
 {
     NSAssert([CMHResultWrapper class] != [self class], @"Attempted to called encodeWithCoder: directly on CMHResultWrapper. Only sublcasses returned by wrapperClassForResultClass: should be used.");
 
-    [aCoder encodeObject:self.studyDescriptor forKey:@"studyDescriptor"];
+    [aCoder encodeObject:self.studyDescriptor forKey:CMHStudyDescriptorKey];
     [self.result encodeWithCoder:aCoder];
 }
 

--- a/Pod/Classes/CMHResultWrapper.m
+++ b/Pod/Classes/CMHResultWrapper.m
@@ -3,11 +3,12 @@
 
 @interface CMHResultWrapper ()
 @property (nonatomic, nonnull) ORKResult *result;
+@property (nonatomic, nonnull) NSString *studyDescriptor;
 @end
 
 @implementation CMHResultWrapper
 
-- (instancetype)initWithResult:(ORKResult *)result
+- (_Nonnull instancetype)initWithResult:(ORKResult *_Nonnull)result studyDescriptor:(NSString *)descriptor;
 {
     self = [super init];
     if (nil == self) return nil;
@@ -15,9 +16,12 @@
     NSAssert([CMHResultWrapper class] != [self class], @"Attempted to called initWithResult: directly on CMHResultWrapper. Only sublcasses returned by wrapperClassForResultClass: should be used.");
 
     self.result = result;
+    self.studyDescriptor = descriptor;
 
     return self;
 }
+
+#pragma mark NSCoding
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
@@ -36,12 +40,24 @@
 {
     NSAssert([CMHResultWrapper class] != [self class], @"Attempted to called encodeWithCoder: directly on CMHResultWrapper. Only sublcasses returned by wrapperClassForResultClass: should be used.");
 
+    [aCoder encodeObject:self.studyDescriptor forKey:@"studyDescriptor"];
     [self.result encodeWithCoder:aCoder];
 }
+
+#pragma mark Getters-Setters
 
 - (ORKResult *)wrappedResult
 {
     return self.result;
+}
+
+- (NSString *)studyDescriptor
+{
+    if (nil == _studyDescriptor) {
+        return @"";
+    }
+
+    return _studyDescriptor;
 }
 
 // Returns the name of the wrapped class, rather than the wrapper class name itself

--- a/Pod/Classes/ORKResult+CMHealth.h
+++ b/Pod/Classes/ORKResult+CMHealth.h
@@ -6,6 +6,8 @@ typedef void(^CMHSaveCompletion)(NSString *_Nullable uploadStatus, NSError *_Nul
 typedef void(^CMHFetchCompletion)(NSArray *_Nullable results, NSError *_Nullable error);
 
 @interface ORKResult (CMHealth)<CMCoding>
+- (void)cmh_saveWithCompletion:(_Nullable CMHSaveCompletion)block;
 - (void)cmh_saveToStudyWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(_Nullable CMHSaveCompletion)block;
 + (void)cmh_fetchUserResultsWithCompletion:(_Nullable CMHFetchCompletion)block;
++ (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(_Nullable CMHFetchCompletion)block;
 @end

--- a/Pod/Classes/ORKResult+CMHealth.h
+++ b/Pod/Classes/ORKResult+CMHealth.h
@@ -6,6 +6,6 @@ typedef void(^CMHSaveCompletion)(NSString *_Nullable uploadStatus, NSError *_Nul
 typedef void(^CMHFetchCompletion)(NSArray *_Nullable results, NSError *_Nullable error);
 
 @interface ORKResult (CMHealth)<CMCoding>
-- (void)cmh_saveWithCompletion:(_Nullable CMHSaveCompletion)block;
+- (void)cmh_saveToStudyWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(_Nullable CMHSaveCompletion)block;
 + (void)cmh_fetchUserResultsWithCompletion:(_Nullable CMHFetchCompletion)block;
 @end

--- a/Pod/Classes/ORKResult+CMHealth.m
+++ b/Pod/Classes/ORKResult+CMHealth.m
@@ -2,8 +2,14 @@
 #import "CMHResultWrapper.h"
 #import "Cocoa+CMHealth.h"
 #import "ORKConsentSignature+CMHealth.h"
+#import "CMHConstants_internal.h"
 
 @implementation ORKResult (CMHealth)
+
+- (void)cmh_saveWithCompletion:(_Nullable CMHSaveCompletion)block
+{
+    [self cmh_saveToStudyWithDescriptor:nil withCompletion:block];
+}
 
 - (void)cmh_saveToStudyWithDescriptor:(NSString *)descriptor withCompletion:(_Nullable CMHSaveCompletion)block;
 {
@@ -46,10 +52,20 @@
     }];
 }
 
-+ (void)cmh_fetchUserResultsWithCompletion:(_Nullable CMHFetchCompletion)block;
++ (void)cmh_fetchUserResultsWithCompletion:(_Nullable CMHFetchCompletion)block
+{
+    [self cmh_fetchUserResultsForStudyWithDescriptor:nil withCompletion:block];
+}
+
++ (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(_Nullable CMHFetchCompletion)block;
 {
     Class wrapperClass = [CMHResultWrapper wrapperClassForResultClass:[self class]];
-    NSString *queryString = [NSString stringWithFormat:@"[%@ = \"%@\"]", CMInternalClassStorageKey, [self class]];
+
+    if (nil == descriptor) {
+        descriptor = @"";
+    }
+
+    NSString *queryString = [NSString stringWithFormat:@"[%@ = \"%@\", %@ = \"%@\"]", CMInternalClassStorageKey, [self class], CMHStudyDescriptorKey, descriptor];
 
     [[CMStore defaultStore] searchUserObjects:queryString
                             additionalOptions:nil

--- a/Pod/Classes/ORKResult+CMHealth.m
+++ b/Pod/Classes/ORKResult+CMHealth.m
@@ -5,14 +5,14 @@
 
 @implementation ORKResult (CMHealth)
 
-- (void)cmh_saveWithCompletion:(_Nullable CMHSaveCompletion)block
+- (void)cmh_saveToStudyWithDescriptor:(NSString *)descriptor withCompletion:(_Nullable CMHSaveCompletion)block;
 {
     Class resultWrapperClass = [CMHResultWrapper wrapperClassForResultClass:[self class]];
 
     NSAssert([[resultWrapperClass class] isSubclassOfClass:[CMHResultWrapper class]],
              @"Fatal Error: Result wrapper class not a result of CMHResultWrapper");
 
-    CMHResultWrapper *resultWrapper = [[resultWrapperClass alloc] initWithResult:self];
+    CMHResultWrapper *resultWrapper = [[resultWrapperClass alloc] initWithResult:self studyDescriptor:descriptor];
 
     [resultWrapper saveWithUser:[CMStore defaultStore].user callback:^(CMObjectUploadResponse *response) {
         if (nil == block) {


### PR DESCRIPTION
Allows the developer to save research kit result objects with a study descriptor and subsequently fetch them with a study descriptor. These are serialized and stored with the objects in CloudMine, but this is transparent to the developer. The SDK still consumes and returns vanilla `ORKResult` objects.