### PR TITLE
Support Study Descriptor on Consent Objects

### DIFF
--- a/CMHealth.podspec
+++ b/CMHealth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "CMHealth"
-  s.version          = "0.1.6"
+  s.version          = "0.1.7"
   s.summary          = "Store and retrieve ResearchKit data to CloudMine with ease"
   s.description      = <<-DESC
                         Store and retrieve ResearchKit data to CloudMine's backend with ease.

--- a/Pod/Classes/CMHConsent.h
+++ b/Pod/Classes/CMHConsent.h
@@ -4,5 +4,6 @@
 @interface CMHConsent : CMObject
 
 @property (nonatomic, nullable, readonly) ORKTaskResult *consentResult;
+@property (nonatomic, nullable, readonly) NSString *studyDescriptor;
 
 @end

--- a/Pod/Classes/CMHConsent.m
+++ b/Pod/Classes/CMHConsent.m
@@ -1,15 +1,19 @@
 #import "CMHConsent_internal.h"
 #import "Cocoa+CMHealth.h"
+#import "CMHConstants_internal.h"
 
 @implementation CMHConsent
 
-- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *)consentResult andSignatureImageFilename:(NSString *)filename
+- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *)consentResult
+                     andSignatureImageFilename:(NSString *)filename
+                        forStudyWithDescriptor:(NSString *)descriptor
 {
     self = [super init];
     if (nil == self) return nil;
 
     self.consentResult = consentResult;
     self.signatureImageFilename = filename;
+    self.studyDescriptor = descriptor;
 
     return self;
 }
@@ -21,6 +25,11 @@
 
     self.consentResult = [aDecoder decodeObjectForKey:@"consentResult"];
     self.signatureImageFilename = [aDecoder decodeObjectForKey:@"signatureImageFilename"];
+    self.studyDescriptor = [aDecoder decodeObjectForKey:CMHStudyDescriptorKey];
+
+    if ([@"" isEqualToString:self.studyDescriptor]) {
+        self.studyDescriptor = nil;
+    }
 
     return self;
 }
@@ -30,6 +39,12 @@
     [super encodeWithCoder:aCoder];
     [aCoder encodeObject:self.consentResult forKey:@"consentResult"];
     [aCoder encodeObject:self.signatureImageFilename forKey:@"signatureImageFilename"];
+
+    if (nil == self.studyDescriptor) {
+        [aCoder encodeObject:@"" forKey:CMHStudyDescriptorKey];
+    } else {
+        [aCoder encodeObject:self.studyDescriptor forKey:CMHStudyDescriptorKey];
+    }
 }
 
 @end

--- a/Pod/Classes/CMHConsent.m
+++ b/Pod/Classes/CMHConsent.m
@@ -23,6 +23,8 @@
     self = [super initWithCoder:aDecoder];
     if (nil == self) return nil;
 
+    // TODO: Pull the wrapper class, decode the object and ensure it is of
+    // the same type as the wrapper class. Set _consentResult to the wrapper.wrappedResult
     self.consentResult = [aDecoder decodeObjectForKey:@"consentResult"];
     self.signatureImageFilename = [aDecoder decodeObjectForKey:@"signatureImageFilename"];
     self.studyDescriptor = [aDecoder decodeObjectForKey:CMHStudyDescriptorKey];

--- a/Pod/Classes/CMHConsent_internal.h
+++ b/Pod/Classes/CMHConsent_internal.h
@@ -4,9 +4,14 @@
 #import "CMHConsent.h"
 
 @interface CMHConsent ()
-- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *_Nullable)consentResult andSignatureImageFilename:(NSString *_Nullable)filename;
+- (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *_Nullable)consentResult
+                     andSignatureImageFilename:(NSString *_Nullable)filename
+                        forStudyWithDescriptor:(NSString *_Nullable)descriptor;
+
 @property (nonatomic, nullable, readwrite) ORKTaskResult *consentResult;
+@property (nonatomic, nullable, readwrite) NSString *studyDescriptor;
 @property (nonatomic, nullable, readwrite) NSString *signatureImageFilename;
+
 @end
 
 #endif

--- a/Pod/Classes/CMHResultWrapper.m
+++ b/Pod/Classes/CMHResultWrapper.m
@@ -1,6 +1,7 @@
 #import "CMHResultWrapper.h"
 #import <objc/runtime.h>
 #import "CMHConstants_internal.h"
+#import <CloudMine/CloudMine.h>
 
 @interface CMHResultWrapper ()
 @property (nonatomic, nonnull) ORKResult *result;
@@ -104,6 +105,8 @@
 
     Class wrapperClass = objc_allocateClassPair([self class], [wrapperClassName cStringUsingEncoding:NSASCIIStringEncoding], 0);
     objc_registerClassPair(wrapperClass);
+
+    [[CMObjectClassNameRegistry sharedInstance] refreshRegistry];
     
     return wrapperClass;
 }

--- a/Pod/Classes/CMHUser.h
+++ b/Pod/Classes/CMHUser.h
@@ -2,10 +2,12 @@
 #import <ResearchKit/ResearchKit.h>
 
 @class CMHUserData;
+@class CMHConsent;
 
 typedef void(^CMHUserAuthCompletion)(NSError * _Nullable error);
 typedef void(^CMHUserLogoutCompletion)(NSError * _Nullable error);
 typedef void(^CMHUploadConsentCompletion)(NSError *_Nullable error);
+typedef void(^CMHFetchConsentCompletion)(CMHConsent *_Nullable consent, NSError *_Nullable error);
 
 @interface CMHUser : NSObject
 
@@ -18,6 +20,9 @@ typedef void(^CMHUploadConsentCompletion)(NSError *_Nullable error);
 - (void)uploadUserConsent:(ORKTaskResult *_Nullable)consentResult
    forStudyWithDescriptor:(NSString *_Nullable)descriptor
             andCompletion:(_Nullable CMHUploadConsentCompletion)block;
+
+- (void)fetchUserConsentForStudyWithDescriptor:(NSString *_Nullable)descriptor
+                                 andCompletion:(_Nonnull CMHFetchConsentCompletion)block;
 
 - (void)loginWithEmail:(NSString *_Nonnull)email
               password:(NSString *_Nonnull)password

--- a/Pod/Classes/CMHUser.h
+++ b/Pod/Classes/CMHUser.h
@@ -18,8 +18,13 @@ typedef void(^CMHFetchConsentCompletion)(CMHConsent *_Nullable consent, NSError 
           andCompletion:(_Nullable CMHUserAuthCompletion)block;
 
 - (void)uploadUserConsent:(ORKTaskResult *_Nullable)consentResult
+           withCompletion:(_Nullable CMHUploadConsentCompletion)block;
+
+- (void)uploadUserConsent:(ORKTaskResult *_Nullable)consentResult
    forStudyWithDescriptor:(NSString *_Nullable)descriptor
             andCompletion:(_Nullable CMHUploadConsentCompletion)block;
+
+- (void)fetchUserConsentForStudyWithCompletion:(_Nonnull CMHFetchConsentCompletion)block;
 
 - (void)fetchUserConsentForStudyWithDescriptor:(NSString *_Nullable)descriptor
                                  andCompletion:(_Nonnull CMHFetchConsentCompletion)block;

--- a/Pod/Classes/CMHUser.m
+++ b/Pod/Classes/CMHUser.m
@@ -54,6 +54,11 @@
     }];
 }
 
+- (void)uploadUserConsent:(ORKTaskResult *)consentResult withCompletion:(CMHUploadConsentCompletion)block
+{
+    [self uploadUserConsent:consentResult forStudyWithDescriptor:nil andCompletion:block];
+}
+
 - (void)uploadUserConsent:(ORKTaskResult *)consentResult forStudyWithDescriptor:(NSString *)descriptor andCompletion:(CMHUploadConsentCompletion)block
 {
     NSError *consentError = nil;
@@ -126,6 +131,11 @@
             }];
         }];
     }];
+}
+
+- (void)fetchUserConsentForStudyWithCompletion:(CMHFetchConsentCompletion)block
+{
+    [self fetchUserConsentForStudyWithDescriptor:nil andCompletion:block];
 }
 
 - (void)fetchUserConsentForStudyWithDescriptor:(NSString *_Nullable)descriptor

--- a/Pod/Classes/CMHUser.m
+++ b/Pod/Classes/CMHUser.m
@@ -73,12 +73,6 @@
         return;
     }
 
-    // TODO: Save this jawn
-    //newUser.familyName = signature.familyName;
-    //newUser.givenName = signature.givenName;
-    //self.userData = [[CMHUserData alloc] initWithInternalUser:[CMHInternalUser currentUser]];
-    //[CMStore defaultStore].user = [CMHInternalUser currentUser];
-
     [self conditionallySaveNameFromSignature:signature withCompletion:^(NSError * _Nullable error) {
         if (nil != error) {
             if (nil != block) {
@@ -98,7 +92,10 @@
                 return;
             }
 
-            CMHConsent *consent = [[CMHConsent alloc] initWithConsentResult:consentResult andSignatureImageFilename:fileResponse.key];
+            CMHConsent *consent = [[CMHConsent alloc] initWithConsentResult:consentResult
+                                                  andSignatureImageFilename:fileResponse.key
+                                                     forStudyWithDescriptor:descriptor];
+            
             [consent saveWithUser:[CMHInternalUser currentUser] callback:^(CMObjectUploadResponse *response) {
                 if (nil == block) {
                     return;

--- a/Pod/Classes/CMHealth.h
+++ b/Pod/Classes/CMHealth.h
@@ -4,6 +4,7 @@
 
 #import "CMHErrors.h"
 #import "CMHUserData.h"
+#import "CMHConsent.h"
 #import "CMHUser.h"
 #import "ORKResult+CMHealth.h"
 


### PR DESCRIPTION
Consent objects now expose a study descriptor field. This allows us to expose methods to the user for uploading and fetching user consent object based on study descriptors.

Note: implementing this functionality exposed bug #26, which is now top priority.